### PR TITLE
feat: allow github-release/release-pr to be run separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Automate releases with Conventional Commit Messages.
 | `upload_url` | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
 | `tag_name` | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
 | `fork`          | Should the PR be created from a fork (does not work with `secrets.GITHUB_TOKEN`) |
+| `command`          | release-please command to run, either `github-release`, or `release-pr` (_defaults to running both_) |
 
 ### Release types supported
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   changelog-types:
     description: 'changlelog commit types'
     require: false
+  command:
+    description: 'release-please command to run, either "github-release", or "release-pr" (defaults to running both)'
+    require: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ async function main () {
   const token = core.getInput('token')
   const fork = core.getInput('fork') ? true : undefined
   const changelogTypes = core.getInput('changelog-types')
+  const command = core.getInput('command') ? core.getInput('command') : undefined;
 
   // Parse the changelogTypes if there are any
   let changelogSections = undefined
@@ -22,37 +23,41 @@ async function main () {
 
   // First we check for any merged release PRs (PRs merged with the label
   // "autorelease: pending"):
-  const gr = new GitHubRelease({
-    label: RELEASE_LABEL,
-    repoUrl: process.env.GITHUB_REPOSITORY,
-    packageName,
-    path,
-    token
-  })
-  const releaseCreated = await gr.createRelease()
-  if (releaseCreated) {
-    // eslint-disable-next-line
-    const { upload_url, tag_name } = releaseCreated
-    core.setOutput('release_created', true)
-    core.setOutput('upload_url', upload_url)
-    core.setOutput('tag_name', tag_name)
+  if (!command || command === 'github-release') {
+    const gr = new GitHubRelease({
+      label: RELEASE_LABEL,
+      repoUrl: process.env.GITHUB_REPOSITORY,
+      packageName,
+      path,
+      token
+    })
+    const releaseCreated = await gr.createRelease()
+    if (releaseCreated) {
+      // eslint-disable-next-line
+      const { upload_url, tag_name } = releaseCreated
+      core.setOutput('release_created', true)
+      core.setOutput('upload_url', upload_url)
+      core.setOutput('tag_name', tag_name)
+    }
   }
 
   // Next we check for PRs merged since the last release, and groom the
   // release PR:
-  const release = ReleasePRFactory.buildStatic(releaseType, {
-    monorepoTags,
-    packageName,
-    path,
-    apiUrl: 'https://api.github.com',
-    repoUrl: process.env.GITHUB_REPOSITORY,
-    fork,
-    token: token,
-    label: RELEASE_LABEL,
-    bumpMinorPreMajor,
-    changelogSections
-  })
-  await release.run()
+  if (!command || command === 'release-pr') {
+    const release = ReleasePRFactory.buildStatic(releaseType, {
+      monorepoTags,
+      packageName,
+      path,
+      apiUrl: 'https://api.github.com',
+      repoUrl: process.env.GITHUB_REPOSITORY,
+      fork,
+      token: token,
+      label: RELEASE_LABEL,
+      bumpMinorPreMajor,
+      changelogSections
+    })
+    await release.run()
+  }
 }
 
 main().catch(err => {

--- a/index.js
+++ b/index.js
@@ -13,10 +13,10 @@ async function main () {
   const token = core.getInput('token')
   const fork = core.getInput('fork') ? true : undefined
   const changelogTypes = core.getInput('changelog-types')
-  const command = core.getInput('command') ? core.getInput('command') : undefined;
+  const command = core.getInput('command') ? core.getInput('command') : undefined
 
   // Parse the changelogTypes if there are any
-  let changelogSections = undefined
+  let changelogSections
   if (changelogTypes) {
     changelogSections = JSON.parse(changelogTypes)
   }


### PR DESCRIPTION
Introduces the `command` option, which allows `github-release` and `release-pr` to be run separately.